### PR TITLE
SEVENTVWEB-404: Don't output in CLI when not verbose

### DIFF
--- a/bin/php/psdcontentbuildercli.php
+++ b/bin/php/psdcontentbuildercli.php
@@ -107,6 +107,8 @@ class psdContentBuilderCLI
             $this->verbose = array_key_exists('verbose', $this->arguments);
         }
 
+        $this->cli->setIsQuiet(!$this->verbose);
+
         try {
             if ($this->initScript()) {
 


### PR DESCRIPTION
Required behavior: CLI output only when the `--verbose` flag is set.