### PR TITLE
SEVENTVWEB-946: (psdcontentbuilder) Use cached node fetch instead of tre...

### DIFF
--- a/classes/contentbuilder/psdcontentbuilder.php
+++ b/classes/contentbuilder/psdcontentbuilder.php
@@ -346,7 +346,7 @@ class psdContentBuilder
         if (is_numeric($location)) {
 
             // Node-ID.
-            return eZContentObjectTreeNode::fetch((int) $location);
+            return psdUtilsFunctionCollection::fetchCachedNode((int) $location);
 
         } elseif (is_string($location) && substr($location, 0, 1) === '/') {
 
@@ -360,7 +360,7 @@ class psdContentBuilder
             // Path-String.
             if (!($node instanceof eZContentObjectTreeNode)) {
                 $node_id = (int) eZURLAliasML::fetchNodeIDByPath($location);
-                $node    = eZContentObjectTreeNode::fetch($node_id);
+                $node    = psdUtilsFunctionCollection::fetchCachedNode($node_id);
             }
 
             if (!($node instanceof eZContentObjectTreeNode)) {
@@ -431,7 +431,7 @@ class psdContentBuilder
 
         $currentUserId = (int) eZUser::currentUserID();
 
-        $parentNode = eZContentObjectTreeNode::fetch($nodeId);
+        $parentNode = psdUtilsFunctionCollection::fetchCachedNode($nodeId);
 
         foreach ($parts as $part) {
             $location .= $part.'/';
@@ -439,7 +439,7 @@ class psdContentBuilder
 
             // Node exists, skip here.
             if ($nodeId !== false) {
-                $parentNode = eZContentObjectTreeNode::fetch($nodeId);
+                $parentNode = psdUtilsFunctionCollection::fetchCachedNode($nodeId);
                 continue;
             }
 


### PR DESCRIPTION
Die Analyse ergab, dass ein Großteil der zeit für Treenode Fetches benötigt wurden. Daher wurden diese durch Cached Node Fetches ersetzt.

Test Sat1Gold:
vorher: 10900 DB Anfragen und 383s
nachher: 92 DB Anfragen und 163s