### PR TITLE
PSDWEBAPP-382: Enhance ContentBuilder performance

### DIFF
--- a/bin/php/psdcontentbuildercli.php
+++ b/bin/php/psdcontentbuildercli.php
@@ -208,13 +208,13 @@ class psdContentBuilderCLI
 
         $files = glob($pattern);
 
+        $builder = new psdContentBuilder();
+
+        $builder->verbose = $this->verbose;
+        $builder->logLineCallback = array($this, 'logLine');
+
         foreach ($files as $file) {
             $this->logLine('Applying structure to content-tree: '.$file, __METHOD__);
-
-            $builder = new psdContentBuilder();
-
-            $builder->verbose = $this->verbose;
-            $builder->logLineCallback = array($this, 'logLine');
 
             $builder->loadFromFile($file);
             $builder->apply();

--- a/bin/php/psdcontentbuildercli.php
+++ b/bin/php/psdcontentbuildercli.php
@@ -115,7 +115,7 @@ class psdContentBuilderCLI
                 // Test if database is empty.
                 $db = eZDB::instance();
                 eZDB::setErrorHandling(eZDB::ERROR_HANDLING_EXCEPTIONS);
-                $db->arrayQuery('SELECT * FROM ezcontentclass');
+                $db->arrayQuery('DESCRIBE ezcontentclass');
 
             }
         } catch (eZDBNoConnectionException $e) {

--- a/classes/contentbuilder/psdcontentbuilder.php
+++ b/classes/contentbuilder/psdcontentbuilder.php
@@ -76,7 +76,7 @@ class psdContentBuilder
     /**
      * Holds an external logline callback. Must accept 2 string-parameters.
      *
-     * @var void
+     * @var callback|array
      */
     public $logLineCallback;
 
@@ -542,7 +542,7 @@ class psdContentBuilder
     {
 
         if (is_callable($this->logLineCallback)) {
-            $this->logLineCallback($str, $method);
+            call_user_func($this->logLineCallback, $str, $method);
 
             return;
         }

--- a/classes/contentbuilder/psdnodebuilder.php
+++ b/classes/contentbuilder/psdnodebuilder.php
@@ -516,7 +516,7 @@ class psdNodeBuilder
 
 
         // Only add new locations in order to catch warnings on existing ones.
-        $location = \SQLILocation::fromNodeID($locationNode->attribute('node_id'));
+        $location = \SQLILocation::fromNode($locationNode);
         if (!self::contentHasLocation($location, $content)) {
             $content->addLocation($location);
         }

--- a/classes/contentbuilder/psdnodebuilder.php
+++ b/classes/contentbuilder/psdnodebuilder.php
@@ -518,7 +518,7 @@ class psdNodeBuilder
         // Only add new locations in order to catch warnings on existing ones.
         $location = \SQLILocation::fromNodeID($locationNode->attribute('node_id'));
         if (!self::contentHasLocation($location, $content)) {
-            $content->addLocation($location, $content);
+            $content->addLocation($location);
         }
 
         $object = $content->getRawContentObject();

--- a/classes/contentbuilder/psdnodebuilder.php
+++ b/classes/contentbuilder/psdnodebuilder.php
@@ -146,6 +146,10 @@ class psdNodeBuilder
             throw new psdContentBuilderValidationException('Invalid structure, must be an array.');
         }
 
+        $eZFindIni = eZINI::instance('ezfind.ini');
+        $previous = $eZFindIni->variable('IndexOptions', 'DisableDirectCommits');
+        $eZFindIni->setVariable('IndexOptions', 'DisableDirectCommits', 'true');
+
         $this->searchEngine = new eZSolr();
         $this->structure = $structure;
 
@@ -159,6 +163,8 @@ class psdNodeBuilder
             $this->contentBuilder->execPath->pop();
 
         }
+
+        $eZFindIni->setVariable('IndexOptions', 'DisableDirectCommits', $previous);
 
         $this->searchEngine->commit();
 


### PR DESCRIPTION
Getestet mit blackfire, leeren Caches und leerer Datenbank.

```bash
cd /var/www/htdocs
mysql -uroot -proot -h localhost 7tv_dev_db < ../assets/database/migrations/dumps/default.sql
bin/migrations current -s 7tv_admin
rm -rf var/cache/* && rm -rf var/*/cache/*
blackfire run php extension/psdcontentbuilder/bin/php/psdcontentbuildercli.php --apply="../fixtures/7tv/*.yaml" --verbose --siteaccess="7tv_admin"
```

x | Vor den Änderungen | Nach den Änderungen
--- | --- | ---
Erster Durchlauf | <img width="728" alt="pre_new" src="https://cloud.githubusercontent.com/assets/67554/9582038/55067db0-5003-11e5-9a3f-0b35f7a1ea6a.png"> | <img width="740" alt="post_new" src="https://cloud.githubusercontent.com/assets/67554/9582045/608af382-5003-11e5-838c-003198bbd88b.png"> 
Zweiter Durchlauf | <img width="708" alt="pre_update" src="https://cloud.githubusercontent.com/assets/67554/9582067/7793c6da-5003-11e5-8a59-0875da8cd93e.png"> | <img width="701" alt="post_update" src="https://cloud.githubusercontent.com/assets/67554/9582071/7e37baf0-5003-11e5-8a6c-5f5a3e5b436e.png">

Den größten Effekt hat das Sparen der Solr-Commits pro geändertem Objekt - jetzt wird nur noch ganz am Ende ein Solr-Commit durchgeführt, was die Gesamtzahl der Commits halbiert.

:octocat:


