### PR TITLE
Add fbTitle and fbDescription to supported fields

### DIFF
--- a/classes/contentbuilder/xrowmetadatatypebuilder.php
+++ b/classes/contentbuilder/xrowmetadatatypebuilder.php
@@ -14,15 +14,17 @@ class xrowMetaDataTypeBuilder extends psdAbstractDatatypeBuilder
      * @var array
      */
     protected $fields = array(
-        'title'       => '',
-        'keywords'    => array(),
-        'description' => '',
-        'priority'    => '',
-        'change'      => '',
-        'googlemap'   => '',
-        'canonical'   => '',
-        'robots'      => '',
-        'extraMeta'   => '',
+        'title'         => '',
+        'keywords'      => array(),
+        'description'   => '',
+        'priority'      => '',
+        'change'        => '',
+        'googlemap'     => '',
+        'canonical'     => '',
+        'robots'        => '',
+        'extraMeta'     => '',
+        'fbTitle'       => '',
+        'fbDescription' => '',
     );
 
 


### PR DESCRIPTION
Removes warnings when executing the content builder CLI.